### PR TITLE
Add support for hierarchical SubjectName and IssuerName fields

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,75 @@ pub trait SubjectPublicKeyInfo {
     fn public_key(&self) -> Self::SubjectPublicKey;
 }
 
+#[derive(Clone)]
+enum RdnType {
+    Country,
+    Organization,
+    OrganizationalUnit,
+    CommonName,
+}
+
+/// An X.509 RelativeDistinguishedName.
+#[derive(Clone)]
+pub struct RelativeDistinguishedName<'a> {
+    typ: RdnType,
+    value: &'a str,
+}
+
+impl<'a> RelativeDistinguishedName<'a> {
+    /// Constructs a Country RDN.
+    ///
+    /// # Panics
+    /// Panics if `value.len() > 64`.
+    pub fn country(value: &'a str) -> Self {
+        assert!(value.len() <= 64);
+
+        RelativeDistinguishedName {
+            typ: RdnType::Country,
+            value,
+        }
+    }
+
+    /// Constructs an Organization RDN.
+    ///
+    /// # Panics
+    /// Panics if `value.len() > 64`.
+    pub fn organization(value: &'a str) -> Self {
+        assert!(value.len() <= 64);
+
+        RelativeDistinguishedName {
+            typ: RdnType::Organization,
+            value,
+        }
+    }
+
+    /// Constructs an OrganizationalUnit RDN.
+    ///
+    /// # Panics
+    /// Panics if `value.len() > 64`.
+    pub fn organizational_unit(value: &'a str) -> Self {
+        assert!(value.len() <= 64);
+
+        RelativeDistinguishedName {
+            typ: RdnType::OrganizationalUnit,
+            value,
+        }
+    }
+
+    /// Constructs a CommonName RDN.
+    ///
+    /// # Panics
+    /// Panics if `value.len() > 64`.
+    pub fn common_name(value: &'a str) -> Self {
+        assert!(value.len() <= 64);
+
+        RelativeDistinguishedName {
+            typ: RdnType::CommonName,
+            value,
+        }
+    }
+}
+
 /// A certificate extension.
 pub struct Extension<'a, O: der::Oid + 'a> {
     /// An OID that specifies the format and definitions of the extension.
@@ -98,7 +167,7 @@ pub mod write {
     };
     use std::io::Write;
 
-    use crate::Extension;
+    use crate::{Extension, RdnType, RelativeDistinguishedName};
 
     use super::{
         der::{write::*, Oid},
@@ -121,18 +190,35 @@ pub mod write {
 
     /// Object identifiers used internally by X.509.
     enum InternalOid {
-        IdAtCommonName,
+        Country,
+        Organization,
+        OrganizationalUnit,
+        CommonName,
     }
 
     impl AsRef<[u64]> for InternalOid {
         fn as_ref(&self) -> &[u64] {
             match self {
-                InternalOid::IdAtCommonName => &[2, 5, 4, 3],
+                InternalOid::Country => &[2, 5, 4, 6],
+                InternalOid::Organization => &[2, 5, 4, 10],
+                InternalOid::OrganizationalUnit => &[2, 5, 4, 11],
+                InternalOid::CommonName => &[2, 5, 4, 3],
             }
         }
     }
 
     impl Oid for InternalOid {}
+
+    impl<'a> RelativeDistinguishedName<'a> {
+        fn oid(&self) -> InternalOid {
+            match self.typ {
+                RdnType::Country => InternalOid::Country,
+                RdnType::CommonName => InternalOid::CommonName,
+                RdnType::Organization => InternalOid::Organization,
+                RdnType::OrganizationalUnit => InternalOid::OrganizationalUnit,
+            }
+        }
+    }
 
     /// From [RFC 5280](https://tools.ietf.org/html/rfc5280#section-4.1):
     /// ```text
@@ -163,15 +249,10 @@ pub mod write {
         ))
     }
 
-    /// Encodes a `str` as an X.509 Common Name.
+    /// Encodes an X.509 RelativeDistinguishedName.
     ///
     /// From [RFC 5280 section 4.1.2.4](https://tools.ietf.org/html/rfc5280#section-4.1.2.4):
     /// ```text
-    /// Name ::= CHOICE { -- only one possibility for now --
-    ///   rdnSequence  RDNSequence }
-    ///
-    /// RDNSequence ::= SEQUENCE OF RelativeDistinguishedName
-    ///
     /// RelativeDistinguishedName ::=
     ///   SET SIZE (1..MAX) OF AttributeTypeAndValue
     ///
@@ -195,17 +276,28 @@ pub mod write {
     ///
     /// ub-common-name INTEGER ::= 64
     /// ```
-    ///
-    /// # Panics
-    ///
-    /// Panics if `name.len() > 64`.
-    fn name<'a, W: Write + 'a>(name: &'a str) -> impl SerializeFn<W> + 'a {
-        assert!(name.len() <= 64);
+    fn relative_distinguished_name<'a, W: Write + 'a>(
+        rdn: &'a RelativeDistinguishedName<'a>,
+    ) -> impl SerializeFn<W> + 'a {
+        der_set((der_sequence((
+            der_oid(rdn.oid()),
+            der_utf8_string(&rdn.value),
+        )),))
+    }
 
-        der_sequence((der_set((der_sequence((
-            der_oid(InternalOid::IdAtCommonName),
-            der_utf8_string(name),
-        )),)),))
+    /// Encodes an X.509 Name.
+    ///
+    /// From [RFC 5280 section 4.1.2.4](https://tools.ietf.org/html/rfc5280#section-4.1.2.4):
+    /// ```text
+    /// Name ::= CHOICE { -- only one possibility for now --
+    ///   rdnSequence  RDNSequence }
+    ///
+    /// RDNSequence ::= SEQUENCE OF RelativeDistinguishedName
+    /// ```
+    fn name<'a, W: Write + 'a>(
+        name: &'a [RelativeDistinguishedName<'a>],
+    ) -> impl SerializeFn<W> + 'a {
+        der_sequence((all(name.iter().map(relative_distinguished_name)),))
     }
 
     /// From [RFC 5280](https://tools.ietf.org/html/rfc5280#section-4.1):
@@ -352,15 +444,13 @@ pub mod write {
     ///
     /// Panics if:
     /// - `serial_number.len() > 20`
-    /// - `issuer.len() > 64`
-    /// - `subject.len() > 64`
     pub fn tbs_certificate<'a, W: Write + 'a, Alg, PKI, O: Oid + 'a>(
         serial_number: &'a [u8],
         signature: &'a Alg,
-        issuer: &'a str,
+        issuer: &'a [RelativeDistinguishedName<'a>],
         not_before: DateTime<Utc>,
         not_after: Option<DateTime<Utc>>,
-        subject: &'a str,
+        subject: &'a [RelativeDistinguishedName<'a>],
         subject_pki: &'a PKI,
         exts: &'a [Extension<'a, O>],
     ) -> impl SerializeFn<W> + 'a
@@ -411,7 +501,9 @@ pub mod write {
 mod tests {
     use chrono::Utc;
 
-    use crate::{write, AlgorithmIdentifier, Extension, SubjectPublicKeyInfo};
+    use crate::{
+        write, AlgorithmIdentifier, Extension, RelativeDistinguishedName, SubjectPublicKeyInfo,
+    };
 
     struct MockAlgorithmId;
 
@@ -446,6 +538,76 @@ mod tests {
     }
 
     #[test]
+    fn names() {
+        const COUNTRY: &str = "NZ";
+        const ORGANIZATION: &str = "ACME";
+        const ORGANIZATIONAL_UNIT: &str = "Road Runner";
+        const COMMON_NAME: &str = "Test-in-a-Box";
+
+        let subject = &[
+            RelativeDistinguishedName::country(COUNTRY),
+            RelativeDistinguishedName::organization(ORGANIZATION),
+            RelativeDistinguishedName::organizational_unit(ORGANIZATIONAL_UNIT),
+            RelativeDistinguishedName::common_name(COMMON_NAME),
+        ];
+        let exts: &[Extension<'_, &[u64]>] = &[];
+
+        let mut tbs_cert = vec![];
+        cookie_factory::gen(
+            write::tbs_certificate(
+                &[],
+                &MockAlgorithmId,
+                &[],
+                Utc::now(),
+                None,
+                subject,
+                &MockPublicKeyInfo,
+                exts,
+            ),
+            &mut tbs_cert,
+        )
+        .unwrap();
+
+        let mut data = vec![];
+        cookie_factory::gen(
+            write::certificate(&tbs_cert, &MockAlgorithmId, &[]),
+            &mut data,
+        )
+        .unwrap();
+
+        let (_, cert) = x509_parser::parse_x509_certificate(&data).unwrap();
+
+        assert_eq!(
+            cert.subject()
+                .iter_country()
+                .map(|c| c.as_str())
+                .collect::<Result<Vec<_>, _>>(),
+            Ok(vec![COUNTRY])
+        );
+        assert_eq!(
+            cert.subject()
+                .iter_organization()
+                .map(|c| c.as_str())
+                .collect::<Result<Vec<_>, _>>(),
+            Ok(vec![ORGANIZATION])
+        );
+        assert_eq!(
+            cert.subject()
+                .iter_organizational_unit()
+                .map(|c| c.as_str())
+                .collect::<Result<Vec<_>, _>>(),
+            Ok(vec![ORGANIZATIONAL_UNIT])
+        );
+        assert_eq!(
+            cert.subject()
+                .iter_common_name()
+                .map(|c| c.as_str())
+                .collect::<Result<Vec<_>, _>>(),
+            Ok(vec![COMMON_NAME])
+        );
+    }
+
+    #[test]
     fn extensions() {
         let signature = MockAlgorithmId;
         let not_before = Utc::now();
@@ -460,10 +622,10 @@ mod tests {
             write::tbs_certificate(
                 &[],
                 &signature,
-                "",
+                &[],
                 not_before,
                 None,
-                "",
+                &[],
                 &subject_pki,
                 exts,
             ),


### PR DESCRIPTION
We retain an opinionated view by only supporting four common attributes
for RelativeDistinguishedName:

- Country
- Organization
- OrganizationalUnit
- CommonName